### PR TITLE
Add Gentoo GURU ebuild to install page

### DIFF
--- a/src/install.md
+++ b/src/install.md
@@ -25,6 +25,24 @@ simply run:
 pkg install iamb
 ```
 
+### Gentoo
+
+On Gentoo, an ebuild is available from the community-managed
+[GURU overlay](https://wiki.gentoo.org/wiki/Project:GURU).
+
+You can enable the GURU overlay with:
+
+```
+eselect repository enable guru
+emerge --sync guru
+```
+
+And then install `iamb` with:
+
+```
+emerge --ask iamb
+```
+
 ### macOS
 
 On macOS a [package][homebrew] is available in Homebrew's repository. To


### PR DESCRIPTION
This is the website-side equivalent of the ulyssa/iamb#374 PR.